### PR TITLE
CI/CD: Improve deployment workflow

### DIFF
--- a/.github/workflows/cd_deploy-to-aks.yml
+++ b/.github/workflows/cd_deploy-to-aks.yml
@@ -29,50 +29,67 @@ on:
           - "Let's Encrypt - Production"  # Ideal when deploying to publicly accessible domain
           - "Let's Encrypt - Staging"     # Ideal when frequently testing deployment (avoid rate limits on prod server)
 jobs:
-  # If triggered by a workflow_run, ensure the CI was successful. If not, skip deployment
   check-context:
     runs-on: ubuntu-latest
     outputs:
-      is_pr_to_main: ${{ steps.get-pr-context.outputs.is_pr_to_main }}
+      should_deploy: ${{ steps.should-deploy.outputs.should_deploy }}
     steps:
-      - name: Get the workflow's triggering context
+      - name: Get context of workflow trigger
+        id: context-check
         run: |
           if [[ "${{ github.event.workflow_run.event }}" == "workflow_dispatch" ]]; then
-            echo "Workflow triggered manually"
-          elif [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
-            echo "This workflow was triggered by the CI workflow's completion. CI was triggered by a pull request."
-            # could use 'break' here and combine with the next step(s), but this is more explicit
+            echo "Workflow triggered manually."
+
           elif [[ "${{ github.event.workflow_run.event }}" == "push" ]]; then
-            echo "This workflow was triggered by the CI workflow's completion. CI was triggered by a push event."
-            echo "The deployment will not be run."; exit 0
+            echo "CD triggered by CI workflow's completion. CI triggered by a push event."
+
+            if [[ "${{ github.event.workflow_run.head.ref }}" == "main" ]]; then
+              echo "Commit was pushed to main branch."
+            else
+              echo "Commit was not pushed to main."
+              echo "deploymentRoadblock=true" >> $GITHUB_ENV
+            fi
+
+          elif [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
+            echo "CD triggered by CI workflow's completion. CI triggered by a pull request event."
+
+            if [[ "${{ github.event.workflow_run.pull_request.base.ref }}" == "main" ]]; then
+              echo "The PR is targeting the main branch."
+            else
+              echo "The PR is not targeting the main branch."
+              echo "deploymentRoadblock=true" >> $GITHUB_ENV
+            fi
           else
-            echo "Error: Unsupported event '${{ github.event.workflow_run.event }}'."; exit 1
+            echo "Error: Unsupported event '${{ github.event.workflow_run.event }}'."
+            echo "deploymentRoadblock=true" >> $GITHUB_ENV
           fi
 
-      - name: Get context on pull request
-        if: ${{ github.event.workflow_run.event == 'pull_request' }}
-        id: get-pr-context
+      - name: Ensure CI success
+        if: ${{ github.event_name == 'workflow_run' }}
         run: |
-          if [[ "${{ github.event.workflow_run.event.pull_request.base.ref }}" == "main" ]]; then
-            echo "PR is to main branch."
-            echo "is_pr_to_main=true" >> $GITHUB_OUTPUT
-          fi
-          # given this workflow is triggered by the CI workflow, we enforce that the CI was successful before proceeding
           if [[ "${{ github.event.workflow_run.conclusion }}" == "success" ]]; then
               echo "CI was successful."
           else
-              echo "CI failed; skipping deployment (workflow will quit here)."; exit 1
+              echo "CI failed."
+              echo "deploymentRoadblock=true" >> $GITHUB_ENV
           fi
-          # extra info for debugging
-          echo "PR base ref: ${{ github.event.workflow_run.event.pull_request.base.ref }}"
-          echo "PR head ref: ${{ github.event.workflow_run.event.pull_request.head.ref }}"
-          echo "PR number: ${{ github.event.workflow_run.event.pull_request.number }}"
-          echo "PR title: ${{ github.event.workflow_run.event.pull_request.title }}"
+
+      - name: Should deploy?
+        id: should-deploy
+        run: |
+          if [[ "$deploymentRoadblock" == 'true' ]]; then
+            echo "Deployment blocked."
+            shouldDeploy=false
+          else
+            echo "Deployment will proceed."
+            shouldDeploy=true
+          fi
+          echo "should_deploy=$shouldDeploy" >> $GITHUB_OUTPUT
 
   prepare-deployment:
     needs: [ check-context ]
     runs-on: ubuntu-latest
-    if: ${{ needs.check-context.outputs.is_pr_to_main == 'true' || github.event.workflow_run.event == 'workflow_dispatch' }}
+    if: ${{ needs.check-context.outputs.should_deploy == 'true' }}
     env:
       ROOT_DOMAIN: "litter.dev"
     outputs:
@@ -214,7 +231,7 @@ jobs:
   deploy-to-aks:
     needs: [ prepare-deployment, check-context ]
     runs-on: ubuntu-latest
-    if: ${{ needs.check-context.outputs.is_pr_to_main == 'true' || github.event.workflow_run.event == 'workflow_dispatch' }}
+    if: ${{ needs.check-context.outputs.should_deploy == 'true' || github.event.workflow_run.event == 'workflow_dispatch' }}
     env:
       # Azure credentials (cannot use azure/login action with service principal)
       #   See: https://github.com/hashicorp/terraform-provider-azurerm/issues/22034

--- a/.github/workflows/cd_pr-cleanup.yml
+++ b/.github/workflows/cd_pr-cleanup.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Select Terraform workspace
         working-directory: ${{ env.TERRAFORM_WORKING_DIR }}
-        run: terraform workspace select ${{ steps.determine_env_code.outputs.env_code }}
+        run: terraform workspace select -or-create ${{ steps.determine_env_code.outputs.env_code }}
 
       - name: Terraform destroy
         working-directory: ${{ env.TERRAFORM_WORKING_DIR }}


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflows to improve deployment logic and streamline the cleanup process. The most important changes include updating the conditions for deployment, modifying the workflow trigger context, and enhancing the Terraform workspace selection.

Improvements to deployment logic:

* [`.github/workflows/cd_deploy-to-aks.yml`](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL32-R92): Updated the condition for deployment to use `should_deploy` instead of `is_pr_to_main`. This ensures that deployments are only triggered when necessary based on the new logic. [[1]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL32-R92) [[2]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL217-R234)

Workflow trigger context enhancements:

* [`.github/workflows/cd_deploy-to-aks.yml`](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL32-R92): Refactored the workflow trigger context checks to handle different events more effectively and set appropriate deployment roadblocks if conditions are not met.

Terraform workspace selection improvement:

* [`.github/workflows/cd_pr-cleanup.yml`](diffhunk://#diff-933c66f24cf8f074dd8e8c49b4da553abe570420ca175051f89df80515a716beL68-R68): Modified the Terraform workspace selection step to use `-or-create` flag, ensuring the workspace is created if it does not exist.