### PR TITLE
CI/CD: Fix variable reference in push event handling

### DIFF
--- a/.github/workflows/cd_deploy-to-aks.yml
+++ b/.github/workflows/cd_deploy-to-aks.yml
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # must use env var for these to avoid CWE-94 & CWE-349:
-      WF_RUN_HEAD: ${{ github.event.workflow_run.head_branch }}
-      WF_RUN_PR_BASE: ${{ github.event.workflow_run.event.pull_request.base.ref }}
+      WF_RUN_HEAD: "${{ github.event.workflow_run.head_branch }}"
+      WF_RUN_PR_BASE: "${{ github.event.workflow_run.pull_requests[0].base.ref }}"
     outputs:
       should_deploy: ${{ steps.should-deploy.outputs.should_deploy }}
     steps:

--- a/.github/workflows/cd_deploy-to-aks.yml
+++ b/.github/workflows/cd_deploy-to-aks.yml
@@ -55,10 +55,10 @@ jobs:
             if [[ "${{ github.event.workflow_run.event }}" == "push" ]]; then
               echo "CI triggered by a push event."
           
-              if [[ "$WF_RUN_REF" == "main" ]]; then
+              if [[ "$WF_RUN_HEAD" == "main" ]]; then
                 echo "Commit was pushed to main branch."
               else
-                echo "Commit was pushed to ${WF_RUN_REF}, not the main branch."
+                echo "Commit was pushed to ${WF_RUN_HEAD}, not the main branch."
                 echo "deploymentRoadblock=true" >> $GITHUB_ENV
               fi
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/cd_deploy-to-aks.yml` file. The change updates the variable used to check the branch name from `WF_RUN_REF` to `WF_RUN_HEAD` to ensure the correct branch is identified during a push event.

* [`.github/workflows/cd_deploy-to-aks.yml`](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL58-R61): Changed variable from `WF_RUN_REF` to `WF_RUN_HEAD` to correctly identify the branch name during push events.