### PR TITLE
CI/CD: Update cleanup workflow and environment variable handling

### DIFF
--- a/.github/workflows/cd_deploy-to-aks.yml
+++ b/.github/workflows/cd_deploy-to-aks.yml
@@ -107,9 +107,9 @@ jobs:
     outputs:
       image_path: ${{ steps.image-path.outputs.image_path }}
       image_tag: ${{ steps.determine-image-tag.outputs.image_tag }}
-      environment_name: ${{ steps.determine-env.outputs.environment_name }}
-      environment_code: ${{ steps.determine-env.outputs.environment_code }}
-      environment_url: ${{ steps.determine-env.outputs.environment_url }}
+      env_name: ${{ steps.determine-env.outputs.env_name }}
+      env_code: ${{ steps.determine-env.outputs.env_code }}
+      env_url: ${{ steps.determine-env.outputs.env_url }}
       acme_provider_url: ${{ steps.determine-acme-url.outputs.acme_provider_url }}
       app_helm_overrides_filename: ${{ steps.select-helm-overrides.outputs.app_helm_overrides_filename }}
     steps:
@@ -133,36 +133,36 @@ jobs:
         id: determine-env
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            environmentName="${{ github.event.inputs.environment }}"
-            case "$environmentName" in
+            envName="${{ github.event.inputs.environment }}"
+            case "$envName" in
               "Production")
-                environmentCode="prod"
+                envCode="prod"
                 ;;
               "Staging")
-                environmentCode="staging"
+                envCode="staging"
                 ;;
               "Development")
-                environmentCode="dev"
+                envCode="dev"
                 ;;
             esac
           elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
             if [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
-              environmentName="Staging"
-              environmentCode="staging"
+              envName="Staging"
+              envCode="staging"
             else  # push events to main branch; deploy to production
-              environmentName="Production"
-              environmentCode="prod"
+              envName="Production"
+              envCode="prod"
             fi
           else
             echo "Error: Unsupported event '${{ github.event_name }}'."; exit 1
           fi
           # set env URL based on env code (e.g. "https://staging.litter.dev")
-          environmentURL="https://$environmentCode.$ROOT_DOMAIN"
+          envURL="https://$envCode.$ROOT_DOMAIN"
 
-          echo "environment_name=$environmentName"  >> $GITHUB_OUTPUT
-          echo "environment_code=$environmentCode"  >> $GITHUB_OUTPUT
-          echo "environment_url=$environmentURL"    >> $GITHUB_OUTPUT
-          echo "Environment: '$environmentName' (code: '$environmentCode', URL: '$environmentURL')"
+          echo "env_name=$envName"  >> $GITHUB_OUTPUT
+          echo "env_code=$envCode"  >> $GITHUB_OUTPUT
+          echo "env_url=$envURL"    >> $GITHUB_OUTPUT
+          echo "Environment: '$envName' (code: '$envCode', URL: '$envURL')"
 
       # Determine the correct ACME Server URL based on the triggering context:
       # - For workflow_dispatch:
@@ -183,7 +183,7 @@ jobs:
               echo "Error: Unsupported ACME provider '${{ github.event.inputs.acme_provider_name }}'."; exit 1
             fi
           elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            if [[ ${{ steps.determine-env.outputs.environment_code }} == "prod" ]]; then
+            if [[ ${{ steps.determine-env.outputs.env_code }} == "prod" ]]; then
               acmeProviderURL="https://acme-v02.api.letsencrypt.org/directory"
             else
               acmeProviderURL="https://acme-staging-v02.api.letsencrypt.org/directory"
@@ -227,7 +227,7 @@ jobs:
       - name: Select Helm Overrides File
         id: select-helm-overrides
         run: |
-          envCode="${{ steps.determine-env.outputs.environment_code }}"
+          envCode="${{ steps.determine-env.outputs.env_code }}"
           if [[ "$envCode" == "prod" ]]; then
             overrideFile="values.prod.yaml"
           elif [[ "$envCode" == "staging" ]]; then
@@ -251,8 +251,8 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       TERRAFORM_WORKING_DIR: "./terraform"
     environment:
-      name: ${{ needs.prepare-deployment.outputs.environment_name }}
-      url: ${{ needs.prepare-deployment.outputs.environment_url }}
+      name: ${{ needs.prepare-deployment.outputs.env_name }}
+      url: ${{ needs.prepare-deployment.outputs.env_url }}
     permissions:
       contents: read
     timeout-minutes: 25 # This can take a WHILE, especially on first deployment & with cheap node SKUs
@@ -275,7 +275,7 @@ jobs:
         working-directory: ${{ env.TERRAFORM_WORKING_DIR }}
         env:
           STATE_KEY_PREFIX: "env-" # Prefix for the state key
-          WORKSPACE_CODE: ${{ needs.prepare-deployment.outputs.environment_code }}
+          WORKSPACE_CODE: ${{ needs.prepare-deployment.outputs.env_code }}
         run: |
           # Construct the new key by prepending the prefix to the workspace code
           stateKey="${STATE_KEY_PREFIX}${WORKSPACE_CODE}.tfstate"
@@ -302,7 +302,7 @@ jobs:
             -var "az_subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
             -var "acme_provider_url=${{ needs.prepare-deployment.outputs.acme_provider_url }}" \
             -var "app_helm_overrides_filename=${{ needs.prepare-deployment.outputs.app_helm_overrides_filename }}" \
-            -var "app_environment=${{ needs.prepare-deployment.outputs.environment_code }}" \
+            -var "app_environment=${{ needs.prepare-deployment.outputs.env_code }}" \
             -var "app_image_repo_url=${{ needs.prepare-deployment.outputs.image_path }}" \
             -var "app_image_tag=${{ needs.prepare-deployment.outputs.image_tag }}" \
             -out=tfplan

--- a/.github/workflows/cd_pr-cleanup.yml
+++ b/.github/workflows/cd_pr-cleanup.yml
@@ -1,4 +1,4 @@
-# This workflow automatically cleans up ephemeral PR staging environment when a PR
+# This workflow automatically cleans up staging PR environment when a PR
 #   targeting the main branch is closed to avoid unnecessary Azure costs.
 name: PR Cleanup
 on:
@@ -8,7 +8,7 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.base.ref == 'main' # only run on PRs to main
+    if: ${{ github.event.pull_request.base.ref == 'main' }} # only run on PRs to main
     env:
       # Azure credentials (cannot use azure/login action with service principal)
       #   See: https://github.com/hashicorp/terraform-provider-azurerm/issues/22034
@@ -24,7 +24,7 @@ jobs:
       - name: Git checkout for Terraform files
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.sha }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
@@ -41,7 +41,7 @@ jobs:
         working-directory: ${{ env.TERRAFORM_WORKING_DIR }}
         env:
           STATE_KEY_PREFIX: "env-" # Prefix for the state key
-          WORKSPACE_CODE: ${{ steps.determine_env_code.outputs.env_code }}
+          WORKSPACE_CODE: "staging"
         run: |
           # Construct the new key by prepending the prefix to the workspace code
           stateKey="${STATE_KEY_PREFIX}${WORKSPACE_CODE}.tfstate"
@@ -57,7 +57,7 @@ jobs:
       - name: Terraform destroy
         working-directory: ${{ env.TERRAFORM_WORKING_DIR }}
         run: |
-          echo "Cleaning up ephemeral environment for PR #${{ github.event.pull_request.number }}"
+          echo "Cleaning up staging environment for PR #${{ github.event.pull_request.number }}"
           terraform destroy -auto-approve \
             -var-file=example.tfvars \
             -var="az_subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \


### PR DESCRIPTION
This pull request includes updates to two GitHub Actions workflows to standardize environment variable names and improve the cleanup process. The main changes involve renaming environment variables for consistency and simplifying the PR cleanup workflow.

### Standardization of environment variable names:

* [`.github/workflows/cd_deploy-to-aks.yml`](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL110-R112): Renamed environment variables from `environment_name`, `environment_code`, and `environment_url` to `env_name`, `env_code`, and `env_url` respectively. [[1]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL110-R112) [[2]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL136-R165) [[3]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL186-R186) [[4]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL230-R230) [[5]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL254-R255) [[6]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL278-R278) [[7]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL305-R305)

### Improvements to PR cleanup workflow:

* [`.github/workflows/cd_pr-cleanup.yml`](diffhunk://#diff-933c66f24cf8f074dd8e8c49b4da553abe570420ca175051f89df80515a716beL1-R1): Updated the description to reflect the cleanup of staging PR environments and fixed the conditional syntax for running the job only on PRs to the main branch. [[1]](diffhunk://#diff-933c66f24cf8f074dd8e8c49b4da553abe570420ca175051f89df80515a716beL1-R1) [[2]](diffhunk://#diff-933c66f24cf8f074dd8e8c49b4da553abe570420ca175051f89df80515a716beL11-R11)
* [`.github/workflows/cd_pr-cleanup.yml`](diffhunk://#diff-933c66f24cf8f074dd8e8c49b4da553abe570420ca175051f89df80515a716beL27-R27): Simplified the Git checkout step by using `github.sha` directly and hardcoded the `WORKSPACE_CODE` to "staging" for consistency. [[1]](diffhunk://#diff-933c66f24cf8f074dd8e8c49b4da553abe570420ca175051f89df80515a716beL27-R27) [[2]](diffhunk://#diff-933c66f24cf8f074dd8e8c49b4da553abe570420ca175051f89df80515a716beL44-R44)
* [`.github/workflows/cd_pr-cleanup.yml`](diffhunk://#diff-933c66f24cf8f074dd8e8c49b4da553abe570420ca175051f89df80515a716beL60-R60): Updated the log message to indicate the cleanup of the staging environment.