### PR TITLE
CI/CD: Update TLS secret configuration and fix secretProviderClass

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -275,7 +275,7 @@ module "cert_manager" {
     }
   ]
   certificates = {
-    "${kubernetes_namespace.env.metadata[0].name}-tls" = {
+    kubernetes_namespace.env.metadata[0].name = {
       namespace   = kubernetes_namespace.env.metadata[0].name
       dns_names = ["${var.app_environment}.${var.az_dns_zone_name}"]
       secret_name = "${kubernetes_namespace.env.metadata[0].name}-tls"
@@ -496,7 +496,7 @@ resource "kubernetes_job" "mongo_restore_job" {
             driver    = "secrets-store.csi.k8s.io"
             read_only = true
             volume_attributes = {
-              secretProviderClass = kubectl_manifest.az_kv_k8s_provider.sensitive_fields
+              secretProviderClass = local.kv_provider_name
             }
           }
         }


### PR DESCRIPTION
This pull request to `terraform/main.tf` includes changes to the configuration of the `cert_manager` module and the `kubernetes_job` resource. The most important changes are focused on improving the maintainability and flexibility of the Terraform configuration.

Changes to `cert_manager` module:

* Updated the `certificates` block to use `kubernetes_namespace.env.metadata[0].name` directly instead of using a string interpolation for the key.

Changes to `kubernetes_job` resource:

* Modified the `volume_attributes` block to use `local.kv_provider_name` for the `secretProviderClass` attribute instead of `kubectl_manifest.az_kv_k8s_provider.sensitive_fields`.