### PR TITLE
CI/CD: Update TLS secret configuration (no 2)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -275,7 +275,7 @@ module "cert_manager" {
     }
   ]
   certificates = {
-    kubernetes_namespace.env.metadata[0].name = {
+    (kubernetes_namespace.env.metadata[0].name) = {
       namespace   = kubernetes_namespace.env.metadata[0].name
       dns_names = ["${var.app_environment}.${var.az_dns_zone_name}"]
       secret_name = "${kubernetes_namespace.env.metadata[0].name}-tls"


### PR DESCRIPTION
This pull request includes a change to the `terraform/main.tf` file to improve the syntax for defining certificates.

Syntax improvement:

* [`terraform/main.tf`](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L278-R278): Modified the syntax for defining `certificates` by adding parentheses around the `kubernetes_namespace.env.metadata[0].name` key.