### PR TITLE
CI/CD: Update env names and adjust cleanup workflow

### DIFF
--- a/.github/workflows/cd_deploy-to-aks.yml
+++ b/.github/workflows/cd_deploy-to-aks.yml
@@ -47,6 +47,9 @@ jobs:
             echo "Workflow triggered manually."
 
           elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            echo "Complete event context JSON: ${{ toJson(github.event) }}"
+            echo "WF_RUN_HEAD: $WF_RUN_HEAD"
+            echo "WF_RUN_PR_BASE: $WF_RUN_PR_BASE"
             echo "Workflow triggered by CI workflow's completion."
 
             if [[ "${{ github.event.workflow_run.event }}" == "push" ]]; then

--- a/.github/workflows/cd_deploy-to-aks.yml
+++ b/.github/workflows/cd_deploy-to-aks.yml
@@ -19,9 +19,9 @@ on:
         required: true
         description: "Deployment environment"
         options:
-          - "Staging"
-          - "Development"
-          - "Production"
+          - "dev"
+          - "staging"
+          - "prod"
       acme_provider_name:
         type: choice
         required: true
@@ -108,7 +108,6 @@ jobs:
       image_path: ${{ steps.image-path.outputs.image_path }}
       image_tag: ${{ steps.determine-image-tag.outputs.image_tag }}
       env_name: ${{ steps.determine-env.outputs.env_name }}
-      env_code: ${{ steps.determine-env.outputs.env_code }}
       env_url: ${{ steps.determine-env.outputs.env_url }}
       acme_provider_url: ${{ steps.determine-acme-url.outputs.acme_provider_url }}
       app_helm_overrides_filename: ${{ steps.select-helm-overrides.outputs.app_helm_overrides_filename }}
@@ -123,46 +122,32 @@ jobs:
           echo "image_path=$imagePath" >> $GITHUB_OUTPUT
           echo "Image path: $imagePath"
 
-      # Determine the deployment environment details (name, code, URL) based on the triggering context:
-      # - For manual dispatch, use the given input for environment name and pre-defined environment codes
+      # Determine the deployment environment details (name & URL) based on the triggering context:
+      # - For manual dispatch, use the given input for environment name
       # - For workflow_run:
       #   - If the CI workflow was triggered by a pull request event, deploy to the staging environment
       # - For push event (always to main branch):
-      #   - Deploy to production environment, with environment code "prod"
+      #   - Deploy to production environment
       - name: Determine Environment
         id: determine-env
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             envName="${{ github.event.inputs.environment }}"
-            case "$envName" in
-              "Production")
-                envCode="prod"
-                ;;
-              "Staging")
-                envCode="staging"
-                ;;
-              "Development")
-                envCode="dev"
-                ;;
-            esac
           elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
             if [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
-              envName="Staging"
-              envCode="staging"
+              envName="staging"
             else  # push events to main branch; deploy to production
-              envName="Production"
-              envCode="prod"
+              envName="prod"
             fi
           else
             echo "Error: Unsupported event '${{ github.event_name }}'."; exit 1
           fi
-          # set env URL based on env code (e.g. "https://staging.litter.dev")
-          envURL="https://$envCode.$ROOT_DOMAIN"
+          # set env URL based on env name (e.g. "https://staging.litter.dev")
+          envURL="https://$envName.$ROOT_DOMAIN"
 
           echo "env_name=$envName"  >> $GITHUB_OUTPUT
-          echo "env_code=$envCode"  >> $GITHUB_OUTPUT
           echo "env_url=$envURL"    >> $GITHUB_OUTPUT
-          echo "Environment: '$envName' (code: '$envCode', URL: '$envURL')"
+          echo "Environment: '$envName' (URL: '$envURL')"
 
       # Determine the correct ACME Server URL based on the triggering context:
       # - For workflow_dispatch:
@@ -183,7 +168,7 @@ jobs:
               echo "Error: Unsupported ACME provider '${{ github.event.inputs.acme_provider_name }}'."; exit 1
             fi
           elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            if [[ ${{ steps.determine-env.outputs.env_code }} == "prod" ]]; then
+            if [[ ${{ steps.determine-env.outputs.env_name }} == "prod" ]]; then
               acmeProviderURL="https://acme-v02.api.letsencrypt.org/directory"
             else
               acmeProviderURL="https://acme-staging-v02.api.letsencrypt.org/directory"
@@ -227,10 +212,10 @@ jobs:
       - name: Select Helm Overrides File
         id: select-helm-overrides
         run: |
-          envCode="${{ steps.determine-env.outputs.env_code }}"
-          if [[ "$envCode" == "prod" ]]; then
+          envName="${{ steps.determine-env.outputs.env_name }}"
+          if [[ "$envName" == "prod" ]]; then
             overrideFile="values.prod.yaml"
-          elif [[ "$envCode" == "staging" ]]; then
+          elif [[ "$envName" == "staging" ]]; then
             overrideFile="values.staging.yaml"
           else
             overrideFile="values.dev.yaml"
@@ -275,7 +260,7 @@ jobs:
         working-directory: ${{ env.TERRAFORM_WORKING_DIR }}
         env:
           STATE_KEY_PREFIX: "env-" # Prefix for the state key
-          WORKSPACE_CODE: ${{ needs.prepare-deployment.outputs.env_code }}
+          WORKSPACE_CODE: ${{ needs.prepare-deployment.outputs.env_name }}
         run: |
           # Construct the new key by prepending the prefix to the workspace code
           stateKey="${STATE_KEY_PREFIX}${WORKSPACE_CODE}.tfstate"
@@ -302,7 +287,7 @@ jobs:
             -var "az_subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
             -var "acme_provider_url=${{ needs.prepare-deployment.outputs.acme_provider_url }}" \
             -var "app_helm_overrides_filename=${{ needs.prepare-deployment.outputs.app_helm_overrides_filename }}" \
-            -var "app_environment=${{ needs.prepare-deployment.outputs.env_code }}" \
+            -var "app_environment=${{ needs.prepare-deployment.outputs.env_name }}" \
             -var "app_image_repo_url=${{ needs.prepare-deployment.outputs.image_path }}" \
             -var "app_image_tag=${{ needs.prepare-deployment.outputs.image_tag }}" \
             -out=tfplan

--- a/.github/workflows/cd_tear-down-aks.yml
+++ b/.github/workflows/cd_tear-down-aks.yml
@@ -1,14 +1,26 @@
-# This workflow automatically cleans up staging PR environment when a PR
-#   targeting the main branch is closed to avoid unnecessary Azure costs.
-name: PR Cleanup
+# This workflow removes all resources from a given environment to avoid unnecessary costs.
+# It is triggered when a PR is closed and the base branch is 'main', automatically cleaning up the staging environment.
+# It can also be manually dispatched to clean up the specified environment.
+name: Tear Down AKS Environment
 on:
+  # Allow manual trigger of workflow to destroy the specified environment
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        required: true
+        description: "Environment to destroy"
+        options:
+          - "dev"
+          - "staging"
+          - "prod"
+  # Automatically trigger when a PR is closed for the Staging environment
   pull_request:
     types: [ closed ]
-
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.base.ref == 'main' }} # only run on PRs to main
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.base.ref == 'main' }}
     env:
       # Azure credentials (cannot use azure/login action with service principal)
       #   See: https://github.com/hashicorp/terraform-provider-azurerm/issues/22034
@@ -41,7 +53,8 @@ jobs:
         working-directory: ${{ env.TERRAFORM_WORKING_DIR }}
         env:
           STATE_KEY_PREFIX: "env-" # Prefix for the state key
-          WORKSPACE_CODE: "staging"
+          # staging if the PR is closed and the base branch is 'main', otherwise use the input value:
+          WORKSPACE_CODE: ${{ github.event.inputs.environment || github.event_name == 'pull_request' && 'staging' }}
         run: |
           # Construct the new key by prepending the prefix to the workspace code
           stateKey="${STATE_KEY_PREFIX}${WORKSPACE_CODE}.tfstate"


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflows for deploying and tearing down AKS environments. The changes primarily focus on simplifying environment naming and improving the flexibility of the workflows.

### Improvements to environment naming and workflow flexibility:

* [`.github/workflows/cd_deploy-to-aks.yml`](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL22-R24): Changed environment options to `dev`, `staging`, and `prod`, and removed the use of `env_code` in favor of `env_name`. [[1]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL22-R24) [[2]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL111) [[3]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL126-R150) [[4]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL186-R171) [[5]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL230-R218) [[6]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL278-R263) [[7]](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL305-R290)
* [`.github/workflows/cd_tear-down-aks.yml`](diffhunk://#diff-c4f67e22b9da62f1e98b2c054e06e2ff1af8ddb8a9354045177ebe56f8005fa5L1-R23): Renamed from `cd_pr-cleanup.yml` and added support for manual dispatch to clean up specified environments. Updated the workflow to use the new environment naming conventions. [[1]](diffhunk://#diff-c4f67e22b9da62f1e98b2c054e06e2ff1af8ddb8a9354045177ebe56f8005fa5L1-R23) [[2]](diffhunk://#diff-c4f67e22b9da62f1e98b2c054e06e2ff1af8ddb8a9354045177ebe56f8005fa5L44-R57)