### PR TITLE
Improve OpenAPI docs

### DIFF
--- a/.github/workflows/cd_deploy-to-aks.yml
+++ b/.github/workflows/cd_deploy-to-aks.yml
@@ -275,6 +275,9 @@ jobs:
     environment:
       name: ${{ needs.prepare-deployment.outputs.env_name }}
       url: ${{ needs.prepare-deployment.outputs.env_url }}
+    concurrency:
+      group: ${{ needs.prepare-deployment.outputs.env_name }}
+      cancel-in-progress: true
     permissions:
       contents: read
     timeout-minutes: 20 # This can take a WHILE, especially on first deployment & with cheap node SKUs

--- a/.github/workflows/cd_deploy-to-aks.yml
+++ b/.github/workflows/cd_deploy-to-aks.yml
@@ -232,7 +232,7 @@ jobs:
           echo "app_helm_overrides_filename=$overrideFile" >> $GITHUB_OUTPUT
           echo "Selected override file: $overrideFile"
 
-      # Decide whether or not to use an existing TLS cert & key from the Azure Key Vault:
+      # Decide whether to use an existing TLS cert & key from the Azure Key Vault:
       # If event is workflow_run:
       #  - always ------------> true; use values from KV
       # If event is workflow_dispatch:

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.1'
     id 'io.spring.dependency-management' version '1.1.7'
+
+    // Generate OpenAPI docs as a build step to allow for keeping a static copy of the API docs
+    //   in the project repository. The static copy will be updated during the CI/CD pipeline.
+    //   See: https://github.com/springdoc/springdoc-openapi-gradle-plugin
+    id 'org.springdoc.openapi-gradle-plugin' version '1.9.0'
 }
 
 group = project.group
@@ -23,18 +28,17 @@ dependencies {
 
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.security:spring-security-crypto'
     implementation 'org.springframework.security:spring-security-oauth2-jose'
-
-    // Docker compose support <-- caused problems
-    // runtimeOnly 'org.springframework.boot:spring-boot-docker-compose'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
     // Spring Data - reactive MongoDB
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 
     // SpringDoc OpenAPI doc generator for reactive WebFlux; this will generate and serve Swagger UI
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.5'
+    implementation 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0'
+    annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0' // generate from Javadoc
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'
@@ -48,11 +52,14 @@ dependencies {
 
     // configuration processor
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
+    implementation 'org.modelmapper:modelmapper:3.0.0'
 }
 
 configurations {
     mockitoAgent
 }
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 
@@ -72,6 +79,7 @@ dependencies {
         transitive = false
     }
 }
+
 tasks {
     test {
         useJUnitPlatform()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,4 @@
+# suppress inspection "DuplicatePropertyInspection" for whole file
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip

--- a/res/img/catinlitterbox.svg
+++ b/res/img/catinlitterbox.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
+<!--suppress ALL -->
 <svg
         xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
         xmlns:dc="http://purl.org/dc/elements/1.1/"

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/App.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/App.java
@@ -2,6 +2,7 @@ package org.ac.cst8277.chard.matt.litter;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
 import io.swagger.v3.oas.annotations.servers.Server;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
@@ -10,14 +11,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories;
 
 /**
- * Main class for Litter application.
- * <p>
- * Slf4j annotation                         -> enables logging
- * Configuration annotation                 -> indicates that it's a configuration class
- * ConfigurationPropertiesScan annotation   -> enables configuration properties scanning
- * SpringBootApplication annotation         -> indicates that it's a Spring Boot app
- * EnableReactiveMongoRepositories          -> enables automagic reactive MongoDB repositories
- * OpenAPIDefinition annotation             -> provides OpenAPI metadata for the app
+ * Main application class for Litter - a Twitter-like social media platform.
+ *
+ * <p>This application provides a reactive REST API for managing messages, subscriptions,
+ * and user accounts. It uses Spring WebFlux for non-blocking reactive endpoints,
+ * MongoDB for data storage, and JWT for authentication.
+ *
+ * <p>The API includes:
+ * <ul>
+ *   <li>User management (registration, login)</li>
+ *   <li>Message publishing and retrieval</li>
+ *   <li>Subscription management between users</li>
+ * </ul>
  */
 @Slf4j
 @Configuration
@@ -26,8 +31,9 @@ import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRep
 @OpenAPIDefinition(
         info = @Info(
                 title = "Litter API",
-                version = "1",
-                description = "Spring Boot API for Litter. For more details, see https://github.com/mchar7/litter"
+                description = "Backend API for Litter. For more details, go to the [GitHub repository](https://github.com/mchar7/litter).",
+                version = "v1", // this is the version of the API, not the application
+                license = @License(name = "GPL-3.0", identifier = "GPL-3.0-or-later")
         ),
         servers = {
                 @Server(url = "http://localhost:8080", description = "Local server"),
@@ -36,9 +42,9 @@ import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRep
 )
 public class App {
     /**
-     * Main method for the Litter application.
+     * Main method to start the Litter application.
      *
-     * @param args app startup arguments (takes none).
+     * @param args Command line arguments (none required)
      */
     public static void main(String[] args) {
         log.info("Starting Litter application...");

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/controller/MessageController.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/controller/MessageController.java
@@ -1,43 +1,37 @@
 package org.ac.cst8277.chard.matt.litter.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Pattern;
 import lombok.extern.slf4j.Slf4j;
+import org.ac.cst8277.chard.matt.litter.dto.CreateMessageRequest;
 import org.ac.cst8277.chard.matt.litter.model.Message;
+import org.ac.cst8277.chard.matt.litter.model.User;
 import org.ac.cst8277.chard.matt.litter.security.LogSanitizer;
 import org.ac.cst8277.chard.matt.litter.service.MessageService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.Map;
-
 /**
- * Controller for handling message-related requests.
+ * Endpoint for handling message-related requests.
  */
 @Slf4j
 @RestController
+@Tag(name = "Message API")
 @RequestMapping("/messages")
-@Tag(name = "Message API", description = "Endpoints for managing messages")
+@EnableReactiveMethodSecurity
 public class MessageController {
-
     private final MessageService messageService;
 
     /**
-     * Constructor for MessageController class.
+     * MessageController constructor.
      *
-     * @param messageService Service that handles message-related operations
+     * @param messageService The MessageService for facilitating message operations.
      */
-    @Autowired
     public MessageController(MessageService messageService) {
         this.messageService = messageService;
     }
@@ -45,172 +39,115 @@ public class MessageController {
     /**
      * Creates a new message with the given content for the authenticated user.
      *
-     * @param jwt      JWT representing the authenticated user (provided in the Authorization header)
-     * @param postData A JSON object containing the message content; the field "content" is required.
-     * @return Mono of the created message
+     * <p>This endpoint returns a reactive Mono that emits the created message and responds with a 201 Created HTTP status.
+     *
+     * @param jwt     A JWT representing the authenticated user.
+     * @param request The request containing the message content.
+     * @return A Mono emitting the created message with HTTP 201 Created status.
      */
-    @Operation(
-            summary = "Create a new message",
-            description = "Creates a new message for the authenticated producer with a given text content. Assigns current timestamp automatically.",
-            responses = {
-                    @ApiResponse(responseCode = "201", description = "Message created successfully",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))),
-                    @ApiResponse(responseCode = "400", description = "Invalid message content"),
-                    @ApiResponse(responseCode = "403", description = "User is not authorized to create message")
-            }
-    )
-    @PostMapping("")
+    @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Mono<Message> createMessage(
-            @Parameter(description = "JWT token representing the authenticated user")
-            @AuthenticationPrincipal Jwt jwt,
-            @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "A JSON object containing the message content. Example: {\"content\": \"Hello, world!\"}",
-                    required = true,
-                    content = @Content(mediaType = "application/json", schema = @Schema(type = "object", example = "{\"content\": \"Hello, world!\"}"))
-            )
-            @RequestBody Map<String, String> postData) {
-        return messageService.createMessage(jwt, postData.get("content"))
-                .doFirst(() -> log.info("Creating message for user {}", LogSanitizer.sanitize(jwt.getSubject())))
-                .doOnSuccess(message -> log.info("Message {} created by user {}",
-                        LogSanitizer.sanitize(message.getMessageId().toString()), LogSanitizer.sanitize(jwt.getSubject())))
-                .doOnError(e -> log.error("Failed to create message for user {}: {}",
-                        LogSanitizer.sanitize(jwt.getSubject()), LogSanitizer.sanitize(e.getMessage())));
+    public Mono<Message> createMessage(@AuthenticationPrincipal Jwt jwt, @RequestBody CreateMessageRequest request) {
+        return messageService.createMessage(jwt, request.getContent())
+                .doOnSuccess(message -> log.info("User '{}' successfully created message with ID: {}",
+                        LogSanitizer.sanitize(jwt.getSubject()), message.getMessageId()))
+                .doOnError(e -> log.error("User '{}' failed to create message. Error: {}",
+                        LogSanitizer.sanitize(jwt.getSubject()), e.getMessage(), e));
     }
 
     /**
      * Deletes a message by its ID.
      *
-     * @param id  ID of the message to delete
-     * @param jwt JWT representing the authenticated user (provided in the Authorization header)
-     * @return Mono of completion
+     * <p>This endpoint returns a reactive Mono that signals completion
+     * and responds with a 204 No Content HTTP status upon successful deletion.
+     *
+     * @param id  The ID of the message to delete.
+     * @param jwt A JWT representing the authenticated user.
+     * @return An empty Mono signaling completion with HTTP 204 No Content status.
      */
-    @Operation(
-            summary = "Delete a message",
-            description = "Deletes the message identified by its ID. Only the message producer or an administrator can perform this action.",
-            responses = {
-                    @ApiResponse(responseCode = "204", description = "Message deleted successfully"),
-                    @ApiResponse(responseCode = "400", description = "Invalid message ID"),
-                    @ApiResponse(responseCode = "403", description = "User not authorized to delete the message")
-            }
-    )
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public Mono<Void> deleteMessage(
-            @Parameter(description = "ID of the message to delete", required = true, example = "606c76a7e3a4e17abc321654")
-            @PathVariable String id,
-            @Parameter(description = "JWT token representing the authenticated user")
-            @AuthenticationPrincipal Jwt jwt) {
+            @AuthenticationPrincipal Jwt jwt, @PathVariable @Pattern(regexp = Message.ID_REGEX) String id) {
         return messageService.deleteMessage(id, jwt)
-                .doFirst(() -> log.info("User {} attempting to delete message {}",
-                        LogSanitizer.sanitize(jwt.getSubject()), LogSanitizer.sanitize(id)))
-                .doOnSuccess(v -> log.info("Message {} deleted by user {}",
-                        LogSanitizer.sanitize(id), LogSanitizer.sanitize(jwt.getSubject())))
-                .doOnError(e -> log.error("Failed to delete message {}: {}",
-                        LogSanitizer.sanitize(id), LogSanitizer.sanitize(e.getMessage())));
+                .doFirst(() -> log.info("Attempting to delete message with ID: {}", id))
+                .doOnSuccess(v -> log.info("Successfully deleted message with ID: {}", id))
+                .doOnError(e -> log.error("Failed to delete message with ID: {}. Error: {}",
+                        id, e.getMessage(), e));
     }
 
     /**
      * Retrieves a message by its ID.
      *
-     * @param id ID of the message to retrieve
-     * @return Mono of the message
+     * <p>This endpoint returns a reactive Mono that emits the message with the specified ID
+     * and responds with a 200 OK HTTP status. If the message is not found, an empty Mono is returned
+     * which the framework will translate to a 404 Not Found response.
+     *
+     * @param id The ID of the message to retrieve.
+     * @return A Mono emitting the message with the specified ID with HTTP 200 OK status.
      */
-    @Operation(
-            summary = "Get a message by ID",
-            description = "Retrieves a message by its unique ID.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "Message retrieved successfully",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))),
-                    @ApiResponse(responseCode = "400", description = "Invalid message ID"),
-                    @ApiResponse(responseCode = "404", description = "Message not found")
-            }
-    )
     @GetMapping("/{id}")
-    public Mono<Message> getMessage(
-            @Parameter(description = "ID of the message to retrieve", required = true, example = "606c76a7e3a4e17abc321654")
-            @PathVariable String id) {
+    public Mono<Message> getMessage(@PathVariable @Pattern(regexp = Message.ID_REGEX) String id) {
         return messageService.getMessageById(id)
-                .doFirst(() -> log.info("Retrieving message {}", LogSanitizer.sanitize(id)))
-                .doOnSuccess(message -> log.info("Retrieved message {}", LogSanitizer.sanitize(message.getMessageId().toString())))
-                .doOnError(e -> log.error("Failed to retrieve message {}: {}",
-                        LogSanitizer.sanitize(id), LogSanitizer.sanitize(e.getMessage())));
+                .doFirst(() -> log.info("Retrieving message with ID: {}", id))
+                .doOnSuccess(message -> log.info("Retrieved message with ID: {}", id))
+                .doOnError(e -> log.error("Failed to retrieve message with ID: {}. Error: {}",
+                        id, e.getMessage(), e));
     }
 
     /**
      * Retrieves messages for a specific producer.
      *
-     * @param producerUsername The username of the producer
-     * @return Flux of messages for the producer
+     * <p>This endpoint returns a reactive Flux that emits messages posted by the specified producer
+     * and responds with a 200 OK HTTP status. If no messages are found, an empty Flux is returned
+     * which will result in an empty array in the response.
+     *
+     * @param producerUsername The username of the producer whose messages to retrieve.
+     * @return A Flux emitting the messages for the specified producer with HTTP 200 OK status.
      */
-    @Operation(
-            summary = "Get messages for a producer",
-            description = "Retrieves all messages posted by the specified producer. Provide the producer's username (e.g., \"producer1\").",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200", description = "Messages retrieved for producer",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(type = "array", implementation = Message.class)
-                            )
-                    ),
-                    @ApiResponse(responseCode = "400", description = "Invalid producer username"),
-                    @ApiResponse(responseCode = "404", description = "Producer not found or no messages")
-            }
-    )
     @GetMapping("/producer/{producerUsername}")
     public Flux<Message> getMessagesForProducer(
-            @Parameter(description = "Username of the producer", required = true, example = "producer1")
-            @PathVariable String producerUsername) {
+            @PathVariable @Pattern(regexp = User.USERNAME_REGEX_STR) String producerUsername) {
         return messageService.getMessagesForProducer(producerUsername)
                 .doFirst(() -> log.info("Retrieving messages for producer {}", LogSanitizer.sanitize(producerUsername)))
                 .doOnComplete(() -> log.info("Retrieved messages for producer {}", LogSanitizer.sanitize(producerUsername)))
-                .doOnError(e -> log.error("Failed to retrieve messages for producer {}: {}",
-                        LogSanitizer.sanitize(producerUsername), LogSanitizer.sanitize(e.getMessage())));
+                .doOnError(e -> log.error("Failed to retrieve messages for producer {}. Error: {}",
+                        LogSanitizer.sanitize(producerUsername), e.getMessage(), e));
     }
 
     /**
-     * Retrieves all messages for the authenticated subscriber.
+     * Retrieves all messages for the authenticated subscriber based on their subscriptions.
      *
-     * @param jwt JWT representing the authenticated user (provided in the Authorization header)
-     * @return Flux of messages for the subscriber
+     * <p>This endpoint returns a reactive Flux that emits messages from producers the subscriber
+     * is following and responds with a 200 OK HTTP status. If no messages are found, an empty Flux
+     * is returned which will result in an empty array in the response.
+     *
+     * @param jwt A JWT representing the authenticated user.
+     * @return A Flux emitting the messages for the subscriber with HTTP 200 OK status.
      */
-    @Operation(
-            summary = "Get messages for subscriber",
-            description = "Retrieves all messages for the authenticated subscriber based on their subscriptions.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "Messages retrieved for subscriber",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(type = "array", implementation = Message.class))),
-                    @ApiResponse(responseCode = "204", description = "No messages found")
-            }, security = @SecurityRequirement(name = "bearerAuth")
-    )
     @GetMapping("/subscribed")
-    public Flux<Message> getAllMessagesForSubscriber(
-            @Parameter(description = "JWT token representing the authenticated user")
-            @AuthenticationPrincipal Jwt jwt) {
+    public Flux<Message> getAllMessagesForSubscriber(@AuthenticationPrincipal Jwt jwt) {
         return messageService.findAllMessagesForSubscriber(jwt)
                 .doFirst(() -> log.info("Retrieving subscribed messages for user {}", LogSanitizer.sanitize(jwt.getSubject())))
                 .doOnComplete(() -> log.info("Retrieved subscribed messages for user {}", LogSanitizer.sanitize(jwt.getSubject())))
-                .doOnError(e -> log.error("Failed to retrieve subscribed messages for user {}: {}",
-                        LogSanitizer.sanitize(jwt.getSubject()), LogSanitizer.sanitize(e.getMessage())));
+                .doOnError(e -> log.error("Failed to retrieve subscribed messages for user {}. Error: {}",
+                        LogSanitizer.sanitize(jwt.getSubject()), e.getMessage(), e));
     }
 
     /**
      * Retrieves all messages in the system.
      *
-     * @return Flux of all messages
+     * <p>This endpoint returns a reactive Flux that emits all messages stored in the system
+     * and responds with a 200 OK HTTP status. If no messages are found, an empty Flux is returned
+     * which will result in an empty array in the response.
+     *
+     * @return A Flux emitting all available messages with HTTP 200 OK status.
      */
-    @Operation(summary = "Get all messages", description = "Retrieves all messages in the system.",
-            responses = @ApiResponse(responseCode = "200", description = "All messages retrieved successfully",
-                    content = @Content(mediaType = "application/json", schema = @Schema(type = "array", implementation = Message.class))))
     @GetMapping("/all")
     public Flux<Message> getAllMessages() {
         return messageService.getAllMessages()
                 .doFirst(() -> log.info("Retrieving all messages"))
                 .doOnComplete(() -> log.info("Finished retrieving all messages"))
-                .doOnError(e -> log.error("Failed to retrieve all messages: {}",
-                        LogSanitizer.sanitize(e.getMessage())));
+                .doOnError(e -> log.error("Failed to retrieve all messages. Error: {}", e.getMessage(), e));
     }
 }

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/controller/SubscriptionController.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/controller/SubscriptionController.java
@@ -48,16 +48,14 @@ public class SubscriptionController {
      */
     @Operation(
             summary = "Create Subscription",
-            description = "Subscribes the authenticated user to the specified producer. " +
-                    "The path parameter must be a valid producer username. " +
-                    "Requires a valid JWT Bearer token.",
+            description = "Subscribes the authenticated user to the specified producer.",
             responses = {
                     @ApiResponse(responseCode = "201", description = "Subscription created successfully",
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = Subscription.class))),
                     @ApiResponse(responseCode = "400", description = "Invalid producer username"),
                     @ApiResponse(responseCode = "409", description = "Already subscribed to this producer")
-            })
-    @SecurityRequirement(name = "bearerAuth")
+            }, security = @SecurityRequirement(name = "bearerAuth")
+    )
     @PutMapping("{producerUsername}")
     @ResponseStatus(HttpStatus.CREATED)
     public Mono<Subscription> createSubscription(
@@ -67,11 +65,9 @@ public class SubscriptionController {
             @PathVariable String producerUsername) {
         return subscriptionService.subscribe(jwt, producerUsername)
                 .doFirst(() -> log.info("User {} attempting to subscribe to producer {}",
-                        LogSanitizer.sanitize(jwt.getSubject()),
-                        LogSanitizer.sanitize(producerUsername)))
+                        LogSanitizer.sanitize(jwt.getSubject()), LogSanitizer.sanitize(producerUsername)))
                 .doOnSuccess(subscription -> log.info("User {} subscribed to producer {}",
-                        LogSanitizer.sanitize(jwt.getSubject()),
-                        LogSanitizer.sanitize(producerUsername)))
+                        LogSanitizer.sanitize(jwt.getSubject()), LogSanitizer.sanitize(producerUsername)))
                 .doOnError(e -> log.error("Failed to create subscription for user {} to producer {}: {}",
                         LogSanitizer.sanitize(jwt.getSubject()),
                         LogSanitizer.sanitize(producerUsername),
@@ -87,14 +83,13 @@ public class SubscriptionController {
      */
     @Operation(
             summary = "Delete Subscription",
-            description = "Deletes the subscription for the authenticated user from the specified producer. " +
-                    "Requires a valid JWT Bearer token.",
+            description = "Deletes the subscription for the authenticated user from the specified producer.",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Subscription deleted successfully"),
                     @ApiResponse(responseCode = "400", description = "Invalid producer username"),
                     @ApiResponse(responseCode = "404", description = "Subscription not found")
-            })
-    @SecurityRequirement(name = "bearerAuth")
+            }, security = @SecurityRequirement(name = "bearerAuth")
+    )
     @DeleteMapping("{producerUsername}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public Mono<Void> deleteSubscription(
@@ -123,13 +118,13 @@ public class SubscriptionController {
      */
     @Operation(
             summary = "Get Subscriptions",
-            description = "Retrieves all subscriptions for the authenticated subscriber. Requires a valid JWT Bearer token.",
+            description = "Retrieves all subscriptions for the authenticated subscriber.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Subscriptions retrieved successfully",
-                            content = @Content(mediaType = "application/json",
-                                    schema = @Schema(type = "array", implementation = Subscription.class))),
-                    @ApiResponse(responseCode = "404", description = "No subscriptions found or user not a subscriber")})
-    @SecurityRequirement(name = "bearerAuth")
+                            content = @Content(mediaType = "application/json", schema = @Schema(type = "array", implementation = Subscription.class))),
+                    @ApiResponse(responseCode = "404", description = "No subscriptions found or user not a subscriber")
+            }, security = @SecurityRequirement(name = "bearerAuth")
+    )
     @GetMapping("")
     public Flux<Subscription> getSubscriptions(
             @Parameter(description = "JWT token representing the authenticated user")
@@ -138,7 +133,6 @@ public class SubscriptionController {
                 .doFirst(() -> log.info("Retrieving subscriptions for user {}", LogSanitizer.sanitize(jwt.getSubject())))
                 .doOnComplete(() -> log.info("Retrieved subscriptions for user {}", LogSanitizer.sanitize(jwt.getSubject())))
                 .doOnError(e -> log.error("Failed to retrieve subscriptions for user {}: {}",
-                        LogSanitizer.sanitize(jwt.getSubject()),
-                        LogSanitizer.sanitize(e.getMessage())));
+                        LogSanitizer.sanitize(jwt.getSubject()), LogSanitizer.sanitize(e.getMessage())));
     }
 }

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/controller/UserManagementController.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/controller/UserManagementController.java
@@ -1,18 +1,19 @@
 package org.ac.cst8277.chard.matt.litter.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.ac.cst8277.chard.matt.litter.dto.LoginRequest;
 import org.ac.cst8277.chard.matt.litter.dto.RegisterRequest;
+import org.ac.cst8277.chard.matt.litter.dto.UserResponse;
 import org.ac.cst8277.chard.matt.litter.model.User;
 import org.ac.cst8277.chard.matt.litter.security.LogSanitizer;
 import org.ac.cst8277.chard.matt.litter.service.UserManagementService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -23,7 +24,14 @@ import reactor.core.publisher.Mono;
 @Slf4j
 @RestController
 @RequestMapping("/user")
-@Tag(name = "User Management", description = "Operations for user registration, login, and retrieval")
+@Tag(name = "User Management API")
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        in = SecuritySchemeIn.HEADER,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
 public class UserManagementController {
     private final UserManagementService userManagementService;
 
@@ -32,112 +40,89 @@ public class UserManagementController {
      *
      * @param usrMgmtSvc Service for handling user management-related operations
      */
-    @Autowired
     public UserManagementController(UserManagementService usrMgmtSvc) {
         userManagementService = usrMgmtSvc;
     }
 
     /**
-     * Registers a new user.
+     * Registers a new user with the provided username and password.
+     *
+     * <p>This endpoint returns a reactive Mono that emits the created user and responds with a 201 Created HTTP status.
+     * Username must be at least 4 alphanumeric characters and password must be strong. If the username is already taken
+     * or if the credentials don't meet the requirements, appropriate error responses will be returned.
      *
      * @param registerRequest A JSON object containing "username" and "password"
-     * @return Mono of the registered user
+     * @return A Mono emitting the registered user with HTTP 201 Created status.
      */
-    @Operation(
-            summary = "Register a new user",
-            description = "Registers a new user with the provided username and password. Username must be at least 3 alphanumeric characters and password must be strong.",
-            responses = {
-                    @ApiResponse(responseCode = "201", description = "User created successfully",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class))),
-                    @ApiResponse(responseCode = "400", description = "Invalid input or user already exists")
-            }
-    )
     @PostMapping("/register")
     @ResponseStatus(HttpStatus.CREATED)
-    public Mono<User> register(
-            @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "JSON payload containing 'username' and 'password'. Example: {\"username\": \"john_doe\", \"password\": \"P@ssw0rd!\"}",
-                    required = true,
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = RegisterRequest.class))
-            )
-            @RequestBody RegisterRequest registerRequest) {
+    public Mono<UserResponse> register(@RequestBody RegisterRequest registerRequest) {
         String username = registerRequest.getUsername();
-        String password = registerRequest.getPassword();
-
-        return userManagementService.register(username, password)
+        return userManagementService.register(username, registerRequest.getPassword())
+                .map(UserResponse::fromUser)
                 .doFirst(() -> log.info("Processing registration for username {}", LogSanitizer.sanitize(username)))
                 .doOnSuccess(user -> log.info("User registered successfully: {}", LogSanitizer.sanitize(user.getUsername())))
-                .doOnError(e -> log.error("Failed to register user {}: {}",
-                        LogSanitizer.sanitize(username), LogSanitizer.sanitize(e.getMessage())));
+                .doOnError(e -> log.error("Failed to register user {}. Error: {}",
+                        LogSanitizer.sanitize(username), e.getMessage(), e));
     }
 
     /**
-     * Logs in a user.
+     * Logs in a user and returns a JWT token.
+     *
+     * <p>This endpoint returns a reactive Mono that emits the JWT token upon successful authentication
+     * and responds with a 200 OK HTTP status. Credentials must be valid. If authentication fails,
+     * a 401 Unauthorized response will be returned.
      *
      * @param loginRequest A JSON object containing "username" and "password"
-     * @return Mono containing a JWT token if login is successful
+     * @return A Mono emitting a JWT token with HTTP 200 OK status if login is successful.
      */
-    @Operation(
-            summary = "User login",
-            description = "Logs in a user and returns a JWT token. Credentials must be valid.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "User logged in successfully, JWT token returned",
-                            content = @Content(mediaType = "text/plain", schema = @Schema(type = "string", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."))),
-                    @ApiResponse(responseCode = "400", description = "Invalid input"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized, invalid credentials")
-            }
-    )
     @PostMapping("/login")
-    public Mono<String> login(
-            @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "JSON payload containing 'username' and 'password'. Example: {\"username\": \"john_doe\", \"password\": \"P@ssw0rd!\"}",
-                    required = true,
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = LoginRequest.class))
-            )
-            @RequestBody LoginRequest loginRequest) {
+    public Mono<String> login(@RequestBody LoginRequest loginRequest) {
         String username = loginRequest.getUsername();
-        String password = loginRequest.getPassword();
-
-        return userManagementService.login(username, password)
+        return userManagementService.login(username, loginRequest.getPassword())
                 .doFirst(() -> log.info("Processing login for user {}", LogSanitizer.sanitize(username)))
                 .doOnSuccess(token -> log.info("User logged in successfully: {}", LogSanitizer.sanitize(username)))
-                .doOnError(e -> log.error("Login failed for user {}: {}",
-                        LogSanitizer.sanitize(username), LogSanitizer.sanitize(e.getMessage())));
+                .doOnError(e -> log.error("Login failed for user {}. Error: {}",
+                        LogSanitizer.sanitize(username), e.getMessage(), e));
     }
 
     /**
-     * Retrieves all registered users.
+     * Retrieves a list of all registered users with basic details.
      *
-     * @return Flux containing user details
+     * <p>This endpoint returns a reactive Flux that emits all registered users
+     * and responds with a 200 OK HTTP status. If no users are found, an empty Flux is returned
+     * which will result in an empty array in the response.
+     * This endpoint requires admin privileges.
+     *
+     * @return A Flux emitting all registered users with HTTP 200 OK status.
      */
-    @Operation(
-            summary = "Get all users",
-            description = "Retrieves a list of all registered users with basic details (id, username, and roles).",
-            responses = @ApiResponse(
-                    responseCode = "200", description = "List of users retrieved successfully",
-                    content = @Content(mediaType = "application/json", schema = @Schema(type = "array", implementation = User.class))))
     @GetMapping("/all")
-    public Flux<User> getAllUsers() {
+    @SecurityRequirement(name = "bearerAuth")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public Flux<UserResponse> getAllUsers() {
         return userManagementService.getAllUsers()
+                .map(UserResponse::fromUser)
                 .doFirst(() -> log.info("Retrieving all users"))
                 .doOnComplete(() -> log.info("Finished retrieving all users"))
-                .doOnError(e -> log.error("Failed to retrieve users: {}", LogSanitizer.sanitize(e.getMessage())));
+                .doOnError(e -> log.error("Failed to retrieve users. Error: {}", e.getMessage(), e));
     }
 
     /**
-     * Retrieves all users with the producer role.
+     * Retrieves a list of all users with the producer role.
      *
-     * @return Flux of user objects representing producers
+     * <p>This endpoint returns a reactive Flux that emits all users with the producer role
+     * and responds with a 200 OK HTTP status. If no producers are found, an empty Flux is returned
+     * which will result in an empty array in the response.
+     *
+     * @return A Flux emitting all users with the producer role with HTTP 200 OK status.
      */
-    @Operation(
-            summary = "Get all producers", description = "Retrieves a list of all users with the producer role.",
-            responses = @ApiResponse(responseCode = "200", description = "List of producers retrieved successfully",
-                    content = @Content(mediaType = "application/json", schema = @Schema(type = "array", implementation = User.class))))
     @GetMapping("/producers")
-    public Flux<User> getAllProducers() {
+    @SecurityRequirement(name = "bearerAuth")
+    public Flux<UserResponse> getAllProducers() {
         return userManagementService.getAllUsersByRole(User.DB_USER_ROLE_PRODUCER_NAME)
+                .map(UserResponse::fromUser)
                 .doFirst(() -> log.info("Retrieving all producers"))
                 .doOnComplete(() -> log.info("Finished retrieving all producers"))
-                .doOnError(e -> log.error("Failed to retrieve producers: {}", LogSanitizer.sanitize(e.getMessage())));
+                .doOnError(e -> log.error("Failed to retrieve producers. Error: {}", e.getMessage(), e));
     }
 }

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/controller/UserManagementController.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/controller/UserManagementController.java
@@ -45,22 +45,21 @@ public class UserManagementController {
      */
     @Operation(
             summary = "Register a new user",
-            description = "Registers a new user with the provided username and password. " +
-                    "Username must be at least 3 alphanumeric characters. " +
-                    "Password must be at least 8 characters long with at least: " +
-                    "1 uppercase letter, 1 lowercase letter, 1 digit, and 1 special character.",
+            description = "Registers a new user with the provided username and password. Username must be at least 3 alphanumeric characters and password must be strong.",
             responses = {
                     @ApiResponse(responseCode = "201", description = "User created successfully",
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class))),
                     @ApiResponse(responseCode = "400", description = "Invalid input or user already exists")
-            })
+            }
+    )
     @PostMapping("/register")
     @ResponseStatus(HttpStatus.CREATED)
     public Mono<User> register(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "JSON payload containing 'username' and 'password'. Example: {\"username\": \"john_doe\", \"password\": \"P@ssw0rd!\"}",
                     required = true,
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = RegisterRequest.class)))
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = RegisterRequest.class))
+            )
             @RequestBody RegisterRequest registerRequest) {
         String username = registerRequest.getUsername();
         String password = registerRequest.getPassword();
@@ -80,20 +79,21 @@ public class UserManagementController {
      */
     @Operation(
             summary = "User login",
-            description = "Logs in a user and returns a JWT token. The JSON payload must include 'username' and 'password'.",
+            description = "Logs in a user and returns a JWT token. Credentials must be valid.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "User logged in successfully, JWT token returned",
-                            content = @Content(mediaType = "text/plain",
-                                    schema = @Schema(type = "string", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."))),
+                            content = @Content(mediaType = "text/plain", schema = @Schema(type = "string", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."))),
                     @ApiResponse(responseCode = "400", description = "Invalid input"),
                     @ApiResponse(responseCode = "401", description = "Unauthorized, invalid credentials")
-            })
+            }
+    )
     @PostMapping("/login")
     public Mono<String> login(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "JSON payload containing 'username' and 'password'. Example: {\"username\": \"john_doe\", \"password\": \"P@ssw0rd!\"}",
                     required = true,
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = LoginRequest.class)))
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = LoginRequest.class))
+            )
             @RequestBody LoginRequest loginRequest) {
         String username = loginRequest.getUsername();
         String password = loginRequest.getPassword();
@@ -110,7 +110,9 @@ public class UserManagementController {
      *
      * @return Flux containing user details
      */
-    @Operation(summary = "Get all users", description = "Retrieves a list of all registered users with basic details (id, username, and roles).",
+    @Operation(
+            summary = "Get all users",
+            description = "Retrieves a list of all registered users with basic details (id, username, and roles).",
             responses = @ApiResponse(
                     responseCode = "200", description = "List of users retrieved successfully",
                     content = @Content(mediaType = "application/json", schema = @Schema(type = "array", implementation = User.class))))
@@ -127,9 +129,9 @@ public class UserManagementController {
      *
      * @return Flux of user objects representing producers
      */
-    @Operation(summary = "Get all producers", description = "Retrieves a list of all users with the producer role.",
-            responses = @ApiResponse(
-                    responseCode = "200", description = "List of producers retrieved successfully",
+    @Operation(
+            summary = "Get all producers", description = "Retrieves a list of all users with the producer role.",
+            responses = @ApiResponse(responseCode = "200", description = "List of producers retrieved successfully",
                     content = @Content(mediaType = "application/json", schema = @Schema(type = "array", implementation = User.class))))
     @GetMapping("/producers")
     public Flux<User> getAllProducers() {

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/dto/CreateMessageRequest.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/dto/CreateMessageRequest.java
@@ -1,0 +1,22 @@
+package org.ac.cst8277.chard.matt.litter.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.ac.cst8277.chard.matt.litter.model.Message;
+
+/**
+ * DTO for create message requests.
+ */
+@Getter
+@Setter
+@SuppressWarnings("ClassWithoutLogger")
+public class CreateMessageRequest {
+    /**
+     * The content of the message.
+     */
+    @JsonProperty
+    @Schema(example = Message.EXAMPLE_TEXT, pattern = Message.TEXT_REGEX)
+    private String content;
+}

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/dto/LoginRequest.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/dto/LoginRequest.java
@@ -1,29 +1,26 @@
 package org.ac.cst8277.chard.matt.litter.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
+import org.ac.cst8277.chard.matt.litter.model.User;
 
 /**
  * DTO for login requests.
  */
 @Getter
 @Setter
-@Slf4j
-@Schema(description = "DTO for login requests")
+@SuppressWarnings("ClassWithoutLogger")
 public class LoginRequest {
-    @Schema(
-            description = "User's username - at least 3 alphanumeric characters.",
-            example = "john_doe",
-            pattern = "^[a-zA-Z0-9]{3,}$"
-    )
+    /**
+     * User's username.
+     */
+    @Pattern(regexp = User.USERNAME_REGEX_STR)
     private String username;
 
-    @Schema(
-            description = "User's password.",
-            example = "P@ssw0rd!",
-            pattern = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,}$"
-    )
+    /**
+     * User's password.
+     */
+    @Pattern(regexp = User.PASSWORD_REGEX_STR)
     private String password;
 }

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/dto/RegisterRequest.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/dto/RegisterRequest.java
@@ -1,29 +1,26 @@
 package org.ac.cst8277.chard.matt.litter.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
+import org.ac.cst8277.chard.matt.litter.model.User;
 
 /**
- * DTO for regster requests.
+ * DTO for register requests.
  */
 @Getter
 @Setter
-@Slf4j
-@Schema(description = "DTO for register requests")
+@SuppressWarnings("ClassWithoutLogger")
 public class RegisterRequest {
-    @Schema(
-            description = "User's username - at least 3 alphanumeric characters.",
-            example = "john_doe",
-            pattern = "^[a-zA-Z0-9]{3,}$"
-    )
+    /**
+     * User's desired username.
+     */
+    @Pattern(regexp = User.USERNAME_REGEX_STR)
     private String username;
 
-    @Schema(
-            description = "User's password - min 8 chars (at least 1 uppercase, 1 lowercase, 1 digit, and 1 special char.",
-            example = "P@ssw0rd!",
-            pattern = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,}$"
-    )
+    /**
+     * User's desired password.
+     */
+    @Pattern(regexp = User.PASSWORD_REGEX_STR)
     private String password;
 }

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/dto/UserResponse.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/dto/UserResponse.java
@@ -1,0 +1,55 @@
+package org.ac.cst8277.chard.matt.litter.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.ac.cst8277.chard.matt.litter.model.User;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+/**
+ * DTO for user information in API responses.
+ * <p>Provides a controlled subset of user information to prevent exposing sensitive data.
+ */
+@Getter
+@Setter
+@Slf4j
+public class UserResponse {
+    /**
+     * Unique ID of the user.
+     */
+    @Schema(type = "string", pattern = User.ID_REGEX)
+    @JsonSerialize(using = ToStringSerializer.class)
+    private ObjectId id;
+
+    /**
+     * The username of the user.
+     */
+    @Schema(example = User.EXAMPLE_USERNAME, pattern = User.USERNAME_REGEX_STR)
+    private String username;
+
+    /**
+     * Roles assigned to the user.
+     */
+    @Schema(example = User.EXAMPLE_ROLES)
+    private List<String> roles;
+
+    /**
+     * Factory method to create UserResponse from User entity.
+     *
+     * @param user The user entity to convert
+     * @return A UserResponse containing only the appropriate fields for API responses
+     */
+    public static UserResponse fromUser(User user) {
+        log.info("Generating UserResponse from User entity");
+        UserResponse response = new UserResponse();
+        response.setId(user.getId());
+        response.setUsername(user.getUsername());
+        response.setRoles(user.getRoles());
+        return response;
+    }
+}

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/exception/ErrorResponse.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/exception/ErrorResponse.java
@@ -1,0 +1,41 @@
+package org.ac.cst8277.chard.matt.litter.exception;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.Instant;
+
+
+/**
+ * Standard error response to be used for API error responses.
+ */
+@Getter
+@Setter
+@SuppressWarnings("ClassWithoutLogger")
+@Schema(contentMediaType = "application/json")
+public class ErrorResponse {
+    /**
+     * Timestamp when the error occurred.
+     */
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private Instant timestamp;
+
+    /**
+     * Human-readable error message.
+     */
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, example = "Specific error shown here.")
+    private String message;
+
+    /**
+     * Overloaded constructor that sets the error message.
+     *
+     * @param message the error message.
+     */
+    ErrorResponse(String message) {
+        timestamp = Instant.now();
+        this.message = message;
+    }
+}

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/exception/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package org.ac.cst8277.chard.matt.litter.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import reactor.core.publisher.Mono;
+
+/**
+ * Global exception handler that converts exceptions to a standardized ErrorResponse.
+ */
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    /**
+     * Handles BadCredentialsException.
+     * <p>This method is called when a BadCredentialsException is thrown.
+     *
+     * @param err the exception to handle
+     * @return Unauthorized status with error message
+     */
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(BadCredentialsException.class)
+    public Mono<ErrorResponse> handleBadCredentialsException(BadCredentialsException err) {
+        log.trace("Handling BadCredentialsException: {}", err.getMessage());
+        return Mono.just(new ErrorResponse(err.getMessage()));
+    }
+
+    /**
+     * Handles IllegalArgumentException.
+     * <p>This method is called when an IllegalArgumentException is thrown.
+     *
+     * @param err the exception to handle
+     * @return Bad Request status with error message
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public Mono<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException err) {
+        log.trace("Handling IllegalArgumentException: {}", err.getMessage());
+        return Mono.just(new ErrorResponse(err.getMessage()));
+    }
+}

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/exception/package-info.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/exception/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package contains the exception classes for the Litter Service.
+ */
+package org.ac.cst8277.chard.matt.litter.exception;

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/model/Message.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/model/Message.java
@@ -26,20 +26,28 @@ public class Message {
      */
     @Id
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID for the message", accessMode = Schema.AccessMode.READ_ONLY)
+    @Schema(description = "Unique ID for the message",
+            accessMode = Schema.AccessMode.READ_ONLY,
+            type = "string",
+            example = "65c1e8314bd9587f9b6bd94f")
     private ObjectId messageId;
 
     /**
      * Timestamp when the message was created.
      */
-    @Schema(description = "Timestamp when the message was created", accessMode = Schema.AccessMode.READ_ONLY, example = "2025-02-23T15:30:00Z")
+    @Schema(description = "Timestamp when the message was created",
+            accessMode = Schema.AccessMode.READ_ONLY,
+            example = "2025-02-23T15:30:00Z")
     private Instant timestamp;
 
     /**
      * Reference to the producer's unique ID.
      */
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID for the producer", accessMode = Schema.AccessMode.READ_ONLY)
+    @Schema(description = "Unique ID for the producer",
+            accessMode = Schema.AccessMode.READ_ONLY,
+            type = "string",
+            example = "65c1e20f4bd9587f9b6bd94d")
     private ObjectId producerId;
 
     /**

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/model/Message.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/model/Message.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 import lombok.Setter;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.ReadOnlyProperty;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.Instant;
 
@@ -18,41 +20,51 @@ import java.time.Instant;
 @Setter
 @Document(collection = "messages")
 @SuppressWarnings("ClassWithoutLogger")
-@Schema(description = "Details of a message published by a producer.")
 public class Message {
+    /**
+     * Regular expression for a valid message.
+     * <p>All characters are allowed, including whitespace.
+     * <p>Length: 1-512 characters.
+     */
+    public static final String TEXT_REGEX = "^.{1,512}$";
+
+    /**
+     * Regular expression for a valid user ID.
+     * <p>BSON ObjectIds, when converted to strings, are a 24-character hexadecimal.
+     */
+    public static final String ID_REGEX = "^[a-f0-9]{24}$";
+
+    /**
+     * Example message content.
+     */
+    public static final String EXAMPLE_TEXT = "Hello, world!";
 
     /**
      * Unique ID for the message.
      */
-    @Id
+    @Id // primary key
+    @ReadOnlyProperty
+    @Schema(type = "string", pattern = ID_REGEX)
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID for the message",
-            accessMode = Schema.AccessMode.READ_ONLY,
-            type = "string",
-            example = "65c1e8314bd9587f9b6bd94f")
     private ObjectId messageId;
 
     /**
      * Timestamp when the message was created.
      */
-    @Schema(description = "Timestamp when the message was created",
-            accessMode = Schema.AccessMode.READ_ONLY,
-            example = "2025-02-23T15:30:00Z")
+    @ReadOnlyProperty
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private Instant timestamp;
 
     /**
      * Reference to the producer's unique ID.
      */
+    @Schema(type = "string", accessMode = Schema.AccessMode.READ_ONLY, pattern = ID_REGEX)
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID for the producer",
-            accessMode = Schema.AccessMode.READ_ONLY,
-            type = "string",
-            example = "65c1e20f4bd9587f9b6bd94d")
     private ObjectId producerId;
 
     /**
-     * The textual content of the message.
+     * The text content of the message.
      */
-    @Schema(description = "Text content of the message", example = "Hello, world!")
+    @Schema(example = EXAMPLE_TEXT, pattern = TEXT_REGEX)
     private String content;
 }

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/model/Subscription.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/model/Subscription.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.ReadOnlyProperty;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 /**
@@ -18,36 +19,33 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Setter
 @Document(collection = "subscriptions")
 @SuppressWarnings("ClassWithoutLogger")
-@Schema(description = "Subscription details linking a subscriber with a producer.")
 public class Subscription {
+    /**
+     * Regular expression for a valid subscription ID.
+     * <p>BSON ObjectIds, when converted to strings, are a 24-character hexadecimal.
+     */
+    private static final String ID_REGEX = "^[a-f0-9]{24}$";
+
     /**
      * Unique ID for the subscription.
      */
-    @Id
+    @Id // primary key
+    @ReadOnlyProperty
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID for the subscription",
-            accessMode = Schema.AccessMode.READ_ONLY,
-            type = "string",
-            example = "65c1e20f4bd9587f9b6bd94d")
+    @Schema(type = "string", accessMode = Schema.AccessMode.READ_ONLY, pattern = ID_REGEX)
     private ObjectId subscriptionId;
 
     /**
      * Unique ID of the subscriber.
      */
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID of the subscriber",
-            accessMode = Schema.AccessMode.READ_ONLY,
-            type = "string",
-            example = "65c1e20f4bd9587f9b6bd94d")
+    @Schema(type = "string", accessMode = Schema.AccessMode.READ_ONLY, pattern = ID_REGEX)
     private ObjectId subscriberId;
 
     /**
      * Unique ID of the producer.
      */
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID of the producer to whom the user is subscribed",
-            accessMode = Schema.AccessMode.READ_ONLY,
-            type = "string",
-            example = "65c1e20f4bd9587f9b6bd94d")
+    @Schema(type = "string", accessMode = Schema.AccessMode.READ_ONLY, pattern = ID_REGEX)
     private ObjectId producerId;
 }

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/model/Subscription.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/model/Subscription.java
@@ -14,30 +14,40 @@ import org.springframework.data.mongodb.core.mapping.Document;
  * Uses Lombok Getter and Setter annotations for auto getter and setter methods.
  * Uses Spring's Document annotation for automagic MongoDB mapping.
  */
-@Setter
 @Getter
+@Setter
 @Document(collection = "subscriptions")
 @SuppressWarnings("ClassWithoutLogger")
+@Schema(description = "Subscription details linking a subscriber with a producer.")
 public class Subscription {
     /**
      * Unique ID for the subscription.
      */
     @Id
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID for the subscription", accessMode = Schema.AccessMode.READ_ONLY)
+    @Schema(description = "Unique ID for the subscription",
+            accessMode = Schema.AccessMode.READ_ONLY,
+            type = "string",
+            example = "65c1e20f4bd9587f9b6bd94d")
     private ObjectId subscriptionId;
 
     /**
      * Unique ID of the subscriber.
      */
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID of the subscriber", accessMode = Schema.AccessMode.READ_ONLY)
+    @Schema(description = "Unique ID of the subscriber",
+            accessMode = Schema.AccessMode.READ_ONLY,
+            type = "string",
+            example = "65c1e20f4bd9587f9b6bd94d")
     private ObjectId subscriberId;
 
     /**
      * Unique ID of the producer.
      */
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID of the producer to whom the user is subscribed", accessMode = Schema.AccessMode.READ_ONLY)
+    @Schema(description = "Unique ID of the producer to whom the user is subscribed",
+            accessMode = Schema.AccessMode.READ_ONLY,
+            type = "string",
+            example = "65c1e20f4bd9587f9b6bd94d")
     private ObjectId producerId;
 }

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/model/User.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/model/User.java
@@ -2,11 +2,14 @@ package org.ac.cst8277.chard.matt.litter.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.ReadOnlyProperty;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
@@ -19,16 +22,35 @@ import java.util.List;
 @Setter
 @Document(collection = "users")
 @SuppressWarnings("ClassWithoutLogger")
-@Schema(description = "User details including ID, username, and roles. Sensitive fields are hidden.")
 public class User {
+    /**
+     * Regular expression for a valid user ID.
+     * <p>BSON ObjectIds, when converted to strings, are a 24-character hexadecimal.
+     */
+    public static final String ID_REGEX = "^[a-f0-9]{24}$";
+
+    /**
+     * Regular expression string for a valid username.
+     * <p>Valid characters: a-z, A-Z, 0-9, underscore, hyphen.
+     * <p>Length: 4-32 characters.
+     */
+    public static final String USERNAME_REGEX_STR = "^[a-zA-Z0-9_-]{4,32}$";
+
+    /**
+     * Regular expression for a secure password.
+     */
+    public static final String PASSWORD_REGEX_STR = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^a-zA-Z\\d]).{8,}$";
+
     /**
      * Role name for administrators.
      */
     public static final String DB_USER_ROLE_ADMIN_NAME = "ROLE_ADMIN";
+
     /**
      * Role name for subscribers.
      */
     public static final String DB_USER_ROLE_SUBSCRIBER_NAME = "ROLE_SUBSCRIBER";
+
     /**
      * Role name for producers.
      */
@@ -39,45 +61,60 @@ public class User {
      */
     @SuppressWarnings("StaticMethodOnlyUsedInOneClass") // will be more relevant once role management is implemented
     public static final Integer ROLES_HASHMAP_DEFAULT_CAP = 4;
+    /**
+     * Example roles for a user.
+     * <p>Valid roles:
+     * <ul>
+     *     <li>{@code ROLE_ADMIN}</li>
+     *     <li>{@code ROLE_SUBSCRIBER}</li>
+     *     <li>{@code ROLE_PRODUCER}</li>
+     * </ul>
+     */
+    public static final String EXAMPLE_ROLES = "[\"ROLE_ADMIN\", \"ROLE_SUBSCRIBER\"]";
+
+    /**
+     * Example username for a user.
+     */
+    public static final String EXAMPLE_USERNAME = "john_doe";
 
     /**
      * Unique ID of the user.
      */
-    @Id // marks this field as the primary key
+    @Id // primary key
+    @ReadOnlyProperty
+    @Schema(type = "string")
+    @Pattern(regexp = ID_REGEX)
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID of the user",
-            accessMode = Schema.AccessMode.READ_ONLY,
-            type = "string",
-            example = "65c1e20f4bd9587f9b6bd94d")
     private ObjectId id;
 
     /**
      * The username of the user.
      */
-    @Schema(description = "Username of the user", example = "john_doe")
+    @Pattern(regexp = USERNAME_REGEX_STR)
+    @Schema(example = EXAMPLE_USERNAME, accessMode = Schema.AccessMode.READ_ONLY)
     private String username;
 
     /**
      * Roles assigned to the user.
      */
-    @Schema(description = "Roles assigned to the user", example = "[\"ROLE_SUBSCRIBER\"]")
+    @Schema(example = EXAMPLE_ROLES, accessMode = Schema.AccessMode.READ_ONLY)
     private List<String> roles;
 
     /**
      * Hashed password.
      */
-    @Schema(hidden = true)
+    @Hidden
     private String passwordHash;
 
     /**
      * Lockout time, if the account is locked.
      */
-    @Schema(hidden = true, description = "The time until which the account is locked, if applicable")
+    @Hidden
     private LocalDateTime lockedUntil;
 
     /**
      * Count of failed login attempts.
      */
-    @Schema(hidden = true, description = "Number of failed login attempts")
+    @Hidden
     private int failedLoginAttempts;
 }

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/model/User.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/model/User.java
@@ -45,7 +45,10 @@ public class User {
      */
     @Id // marks this field as the primary key
     @JsonSerialize(using = ToStringSerializer.class)
-    @Schema(description = "Unique ID of the user", accessMode = Schema.AccessMode.READ_ONLY)
+    @Schema(description = "Unique ID of the user",
+            accessMode = Schema.AccessMode.READ_ONLY,
+            type = "string",
+            example = "65c1e20f4bd9587f9b6bd94d")
     private ObjectId id;
 
     /**
@@ -61,7 +64,7 @@ public class User {
     private List<String> roles;
 
     /**
-     * Hashed password (hidden from API responses).
+     * Hashed password.
      */
     @Schema(hidden = true)
     private String passwordHash;
@@ -73,7 +76,7 @@ public class User {
     private LocalDateTime lockedUntil;
 
     /**
-     * Count of failed login attempts (hidden).
+     * Count of failed login attempts.
      */
     @Schema(hidden = true, description = "Number of failed login attempts")
     private int failedLoginAttempts;

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/repository/SubscriptionRepository.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/repository/SubscriptionRepository.java
@@ -16,12 +16,12 @@ import reactor.core.publisher.Mono;
 public interface SubscriptionRepository extends ReactiveMongoRepository<Subscription, String> {
 
     /**
-     * Method for finding subscriptions by the subscriber's user ID.
+     * Method for looking up all subscriptions by the subscriber's ID.
      *
      * @param subscriberId user ID of the subscriber
      * @return Flux of subscriptions found
      */
-    Flux<Subscription> findBySubscriberId(ObjectId subscriberId);
+    Flux<Subscription> getSubscriptionsBySubscriberId(ObjectId subscriberId);
 
     /**
      * Method for looking up a subscription by the subscriber and producer's ID.
@@ -30,5 +30,5 @@ public interface SubscriptionRepository extends ReactiveMongoRepository<Subscrip
      * @param producerId   userID of the producer
      * @return Mono of the subscription found
      */
-    Mono<Subscription> findBySubscriberIdAndProducerId(ObjectId subscriberId, ObjectId producerId);
+    Mono<Subscription> getSubscriptionBySubscriberIdAndProducerId(ObjectId subscriberId, ObjectId producerId);
 }

--- a/src/main/java/org/ac/cst8277/chard/matt/litter/repository/UserRepository.java
+++ b/src/main/java/org/ac/cst8277/chard/matt/litter/repository/UserRepository.java
@@ -5,6 +5,7 @@ import org.ac.cst8277.chard.matt.litter.model.User;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -32,4 +33,12 @@ public interface UserRepository extends ReactiveMongoRepository<User, String> {
      */
     @NonNull
     <S extends User> Mono<S> save(@NonNull S entity);
+
+    /**
+     * Method to find all Users with a role.
+     *
+     * @param role the role to search for.
+     * @return Flux emitting all Users with the role.
+     */
+    Flux<User> findByRolesContains(String role);
 }

--- a/src/test/java/org/ac/cst8277/chard/matt/litter/repository/SubscriptionRepositoryIntegrationTest.java
+++ b/src/test/java/org/ac/cst8277/chard/matt/litter/repository/SubscriptionRepositoryIntegrationTest.java
@@ -72,7 +72,7 @@ class SubscriptionRepositoryIntegrationTest {
     /**
      * Tests saving a subscription and finding it by subscriberId and producerId.
      * <p>
-     * Tests on: save(Subscription sub), findBySubscriberIdAndProducerId(ObjectId subId, ObjectId prodId)
+     * Tests on: save(Subscription sub), getSubscriptionBySubscriberIdAndProducerId(ObjectId subId, ObjectId prodId)
      * Expected: The subscription is returned correctly.
      */
     @Test
@@ -89,7 +89,7 @@ class SubscriptionRepositoryIntegrationTest {
         // perform the save and find operations
         Mono<Void> saveOperation = subscriptionRepository.save(subscription).then();
         Mono<Subscription> findOperation = saveOperation.then(
-                subscriptionRepository.findBySubscriberIdAndProducerId(subscriberId, producerId)
+                subscriptionRepository.getSubscriptionBySubscriberIdAndProducerId(subscriberId, producerId)
         );
 
         // verify the subscription was saved and found
@@ -110,7 +110,7 @@ class SubscriptionRepositoryIntegrationTest {
      * Expected: Successfully retrieves subscriptions -- only those from the specified subscriber.
      */
     @Test
-    void testFindBySubscriberId() {
+    void testGetAllForSubscriber() {
         logger.info("Testing findBySubscriberId with multiple subscriptions...");
 
         ObjectId subA = new ObjectId();
@@ -134,9 +134,9 @@ class SubscriptionRepositoryIntegrationTest {
                 .thenMany(subscriptionRepository.save(subscription3));
 
         // expect 2 subscriptions for findFluxSubA, check that they match the subscriber ID
-        StepVerifier.create(insertFlux.thenMany(subscriptionRepository.findBySubscriberId(subA)))
-                .assertNext(sub -> assertEquals(subA, sub.getSubscriberId(), "Expected matching subscriber ID"))
-                .assertNext(sub -> assertEquals(subA, sub.getSubscriberId(), "Expected matching subscriber ID"))
+        StepVerifier.create(insertFlux.thenMany(subscriptionRepository.getSubscriptionsBySubscriberId(subA)))
+                .assertNext(sub -> assertEquals(subA, sub.getSubscriberId(), "SubscriberId should match"))
+                .assertNext(sub -> assertEquals(subA, sub.getSubscriberId(), "SubscriberId should match"))
                 .verifyComplete();
 
         logger.info("testFindBySubscriberId verified filtering by subscriberId.");


### PR DESCRIPTION
This pull request includes various changes aimed at improving code readability and consistency across multiple files in the project. The changes primarily involve simplifying descriptions, consolidating annotations, and refining logging statements.

### Code readability and consistency improvements:

* [`src/main/java/org/ac/cst8277/chard/matt/litter/controller/MessageController.java`](diffhunk://#diff-e441f9f02b5e084a7823cc99cc12497b741de9394bdc04973c0eaa17e26275d1L54-L64): Simplified descriptions in `createMessage`, `deleteMessage`, `getMessage`, `getMessagesForProducer`, and `getAllMessagesForSubscriber` methods. Consolidated `@SecurityRequirement` annotations into the `@Operation` annotation. Improved logging statements by sanitizing message IDs. [[1]](diffhunk://#diff-e441f9f02b5e084a7823cc99cc12497b741de9394bdc04973c0eaa17e26275d1L54-L64) [[2]](diffhunk://#diff-e441f9f02b5e084a7823cc99cc12497b741de9394bdc04973c0eaa17e26275d1L73-R76) [[3]](diffhunk://#diff-e441f9f02b5e084a7823cc99cc12497b741de9394bdc04973c0eaa17e26275d1L96-L104) [[4]](diffhunk://#diff-e441f9f02b5e084a7823cc99cc12497b741de9394bdc04973c0eaa17e26275d1L143-R135) [[5]](diffhunk://#diff-e441f9f02b5e084a7823cc99cc12497b741de9394bdc04973c0eaa17e26275d1L171-R169) [[6]](diffhunk://#diff-e441f9f02b5e084a7823cc99cc12497b741de9394bdc04973c0eaa17e26275d1L192-L201) [[7]](diffhunk://#diff-e441f9f02b5e084a7823cc99cc12497b741de9394bdc04973c0eaa17e26275d1L210-R197) [[8]](diffhunk://#diff-e441f9f02b5e084a7823cc99cc12497b741de9394bdc04973c0eaa17e26275d1L220-R206)

* [`src/main/java/org/ac/cst8277/chard/matt/litter/controller/SubscriptionController.java`](diffhunk://#diff-a4f4f8a2b6a367a718b979156b1a9a13ef168ecbdb984154c117fdc84b4ef136L51-R58): Simplified descriptions in `createSubscription`, `deleteSubscription`, and `getSubscriptions` methods. Consolidated `@SecurityRequirement` annotations into the `@Operation` annotation. Improved logging statements by sanitizing producer usernames. [[1]](diffhunk://#diff-a4f4f8a2b6a367a718b979156b1a9a13ef168ecbdb984154c117fdc84b4ef136L51-R58) [[2]](diffhunk://#diff-a4f4f8a2b6a367a718b979156b1a9a13ef168ecbdb984154c117fdc84b4ef136L70-R70) [[3]](diffhunk://#diff-a4f4f8a2b6a367a718b979156b1a9a13ef168ecbdb984154c117fdc84b4ef136L90-R92) [[4]](diffhunk://#diff-a4f4f8a2b6a367a718b979156b1a9a13ef168ecbdb984154c117fdc84b4ef136L126-R127) [[5]](diffhunk://#diff-a4f4f8a2b6a367a718b979156b1a9a13ef168ecbdb984154c117fdc84b4ef136L141-R136)

* [`src/main/java/org/ac/cst8277/chard/matt/litter/controller/UserManagementController.java`](diffhunk://#diff-a242ff7eb196861c385a434d8120c4708f7793d38cf082b9a74495f0af2dc845L48-R62): Simplified descriptions in `register`, `login`, `getAllUsers`, and `getAllProducers` methods. Consolidated `@SecurityRequirement` annotations into the `@Operation` annotation. [[1]](diffhunk://#diff-a242ff7eb196861c385a434d8120c4708f7793d38cf082b9a74495f0af2dc845L48-R62) [[2]](diffhunk://#diff-a242ff7eb196861c385a434d8120c4708f7793d38cf082b9a74495f0af2dc845L83-R96) [[3]](diffhunk://#diff-a242ff7eb196861c385a434d8120c4708f7793d38cf082b9a74495f0af2dc845L113-R115) [[4]](diffhunk://#diff-a242ff7eb196861c385a434d8120c4708f7793d38cf082b9a74495f0af2dc845L130-R134)

### Minor changes:

* [`.github/workflows/cd_deploy-to-aks.yml`](diffhunk://#diff-444fff86d3e2076d7bd778e608465a494c577c66deb2546bdd198c9564d2f2afL235-R235): Minor grammatical correction in a comment.
* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceR1): Added a suppression for "DuplicatePropertyInspection".